### PR TITLE
Get Dialyzer running without errors

### DIFF
--- a/bench/ets_hash_ring_bench.exs
+++ b/bench/ets_hash_ring_bench.exs
@@ -5,7 +5,7 @@ defmodule ETSHashRingBench do
   @name HashRingBench.ETSRing
   @nodes ["hash-ring-1-1", "hash-ring-1-2", "hash-ring-1-3", "hash-ring-1-4"]
   @replicas 512
-  @overrides %{"1234254543" => 1}
+  @overrides %{"1234254543" => [1]}
 
   setup_all do
     Ring.Config.start_link()

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -232,7 +232,7 @@ defmodule ExHashRing.HashRing.ETS do
     end
   end
 
-  defp do_find_nodes(_table, _gen, 0, _remaining, _hash, _found, _found_length) do
+  defp do_find_nodes(_table, _gen, 0, _remaining, _hash, found, _found_length) do
     Enum.reverse(found)
   end
   

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -233,6 +233,10 @@ defmodule ExHashRing.HashRing.ETS do
     end
   end
 
+  defp do_find_nodes(_table, _gen, 0, _remaining, _hash, _found, _found_length) do
+    Enum.reverse(found)
+  end
+  
   def handle_call(
         {:set_nodes, nodes},
         _from,

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -201,8 +201,7 @@ defmodule ExHashRing.HashRing.ETS do
     Enum.reverse(found)
   end
 
-  defp do_find_nodes(_table, _gen, num_nodes, _remaining, _hash, found, num_nodes)
-       when num_nodes > 0 do
+  defp do_find_nodes(_table, _gen, num_nodes, _remaining, _hash, found, num_nodes) do
     Enum.reverse(found)
   end
 

--- a/lib/hash_ring/ets_config.ex
+++ b/lib/hash_ring/ets_config.ex
@@ -3,10 +3,10 @@ defmodule ExHashRing.HashRing.ETS.Config do
 
   @type t :: %__MODULE__{}
   @type ring_gen :: integer
-  @type num_nodes :: integer
-  @type override_map :: %{atom => [binary]}
+  @type num_nodes :: non_neg_integer
+  @type override_map :: %{optional(term) => [binary]}
   @type config ::
-          {reference, ring_gen, num_nodes} | {reference, ring_gen, num_nodes, override_map}
+          {:ets.tid(), ring_gen, num_nodes} | {:ets.tid(), ring_gen, num_nodes, override_map}
 
   defstruct monitored_pids: %{}
 

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -10,16 +10,16 @@ defmodule ExHashRing.HashRing.Utils do
 
   def hash(key), do: hash("#{key}")
 
-  @spec gen_items([{binary, integer}]) :: [{integer, binary}]
-  @spec gen_items(binary, integer) :: [{integer, binary}]
-  def gen_items([]), do: []
-  def gen_items(nodes), do: do_gen_items(nodes, [])
-  def gen_items([], _num_replicas), do: []
-
-  def gen_items(nodes, default_num_replicas) do
-    nodes = for node <- nodes, do: {node, default_num_replicas}
-    gen_items(nodes)
+  @spec transform_nodes([binary], integer) :: [{binary, integer}]
+  def transform_nodes(nodes, default_num_replicas) do
+    Enum.map(nodes, fn
+      {_node, _num_replicas} = item -> item
+      node -> {node, default_num_replicas}
+    end)
   end
+
+  @spec gen_items([{binary, integer}]) :: [{integer, binary}]
+  def gen_items(nodes), do: do_gen_items(nodes, [])
 
   defp do_gen_items([], items) do
     Enum.sort(items, &(elem(&1, 0) < elem(&2, 0)))


### PR DESCRIPTION
This PR resolves all of the problems that Dialyzer finds within the project. Most of them are benign, but they are the result of incorrect or invalid typespecs.

Of note, I removed the find_next_highest_item clause that matches against 0 nodes. We're guaranteed to have > than 0 nodes at this point, and so that clause could never be hit. I added a guard to protect against this invariant changing in the future.

I also moved the private `ExHashRing.HashRing.ETS.transform_nodes/2` to be a public function `ExHashRing.HashRing.Utils.transform_nodes/2`, to also be called from `ExHashRing.HashRing`. I did this to simplify the interface of `ExHashRing.HashRing.Utils.gen_items/2`, which previously had a few different clauses, some of them typed incorrectly.

I noticed that `ExHashRing.HashRing.find_override/2` was public, but located in the private section of the module. I'm assuming this was a typo, but to avoid changing the public interface of the module, I simply moved it to the corresponding location for now.

I think the most controversial changes are matching against `%HashRing{}` in each of the public functions in `ExHashRing.HashRing`. I think doing so is clearer, and it ensures we're always working with sane data, but it is technically a breaking change, so let me know if you'd like me to remove that change from this PR.

I'd appreciate clarification on the type of `override_map`. Based on the code, I think I defined it properly, but it's possible that there's a more precise type I'm missing.

Anyway, I know this PR comes out of nowhere, but let me know if there's anything you'd like changed in it :)

Dialyzer run before my changes:
```bash
❯ mix dialyzer
Compiling 4 files (.ex)
Checking PLT...
[:compiler, :elixir, :kernel, :stdlib]
PLT is up to date!
Starting Dialyzer
dialyzer args: [
  check_plt: false,
  init_plt: '/Users/shane/dev/ex_hash_ring/_build/dev/dialyxir_erlang-21.2.5_elixir-1.8.1_deps-dev.plt',
  files_rec: ['/Users/shane/dev/ex_hash_ring/_build/dev/lib/ex_hash_ring/ebin'],
  warnings: [:unknown]
]
done in 0m1.36s
lib/hash_ring.ex:13: Function new/0 has no local return
lib/hash_ring.ex:13: The call 'Elixir.ExHashRing.HashRing':new([]) will never return since it differs in the 1st argument from the success typing arguments: (binary())
lib/hash_ring.ex:15: Invalid type specification for function 'Elixir.ExHashRing.HashRing':new/3. The success typing is (binary(),integer(),_) -> #{'items':=tuple(), 'nodes':=binary(), 'num_replicas':=integer(), _=>_}
lib/hash_ring.ex:20: Invalid type specification for function 'Elixir.ExHashRing.HashRing':set_nodes/2. The success typing is (#{'nodes':=_, _=>_},binary()) -> #{'items':=tuple(), 'nodes':=binary(), 'num_replicas':=integer(), _=>_}
lib/hash_ring.ex:25: Invalid type specification for function 'Elixir.ExHashRing.HashRing':add_node/2. The success typing is (#{'nodes':=_, _=>_},_) -> 'error'
lib/hash_ring.ex:30: The call 'Elixir.ExHashRing.HashRing':rebuild(#{'nodes':=nonempty_maybe_improper_list(), _=>_}) will never return since it differs in the 1st argument from the success typing arguments: (#{'items':=_, 'nodes':=binary(), 'num_replicas':=integer(), _=>_})
lib/hash_ring.ex:34: Invalid type specification for function 'Elixir.ExHashRing.HashRing':remove_node/2. The success typing is (#{'nodes':=_, _=>_},_) -> 'error'
lib/hash_ring.ex:37: The call 'Elixir.ExHashRing.HashRing':rebuild(#{'nodes':=[any()], _=>_}) will never return since it differs in the 1st argument from the success typing arguments: (#{'items':=_, 'nodes':=binary(), 'num_replicas':=integer(), _=>_})
lib/hash_ring.ex:43: Invalid type specification for function 'Elixir.ExHashRing.HashRing':set_overrides/2. The success typing is (#{'overrides':=_, _=>_},_) -> {'ok',#{'items':=tuple(), 'nodes':=binary(), 'num_replicas':=integer(), _=>_}}
lib/hash_ring.ex:53: Overloaded contract for 'Elixir.ExHashRing.HashRing':find_node/2 has overlapping domains; such contracts are currently unsupported and are simply ignored
lib/hash_ring.ex:63: Invalid type specification for function 'Elixir.ExHashRing.HashRing':find_node_inner/2. The success typing is (#{'items':=tuple(), _=>_},atom() | binary() | integer()) -> any()
lib/hash_ring.ex:70: Overloaded contract for 'Elixir.ExHashRing.HashRing':find_nodes/3 has overlapping domains; such contracts are currently unsupported and are simply ignored
lib/hash_ring/ets.ex:45: Function init/1 has no local return
lib/hash_ring/ets.ex:75: Function add_node/2 has no local return
lib/hash_ring/ets.ex:75: The call 'Elixir.ExHashRing.HashRing.ETS':add_node(__@1::any(),__@2::any(),'nil') breaks the contract (atom(),binary(),integer()) -> {'ok',[{binary(),integer()}]} | {'error','node_exists'}
lib/hash_ring/ets.ex:143: Function find_node_inner/4 has no local return
lib/hash_ring/ets.ex:329: Function rebuild/1 has no local return
lib/hash_ring/ets.ex:354: The call 'Elixir.ExHashRing.HashRing.ETS.Config':set(_name@1::any(),pid(),_config@1::{atom() | ets:tid(),number(),non_neg_integer()} | {atom() | ets:tid(),number(),non_neg_integer(),map()}) contains an opaque term as 3rd argument when terms of different types are expected in these positions
lib/hash_ring/ets.ex:374: Function find_next_highest_item/4 has no local return
lib/hash_ring/ets.ex:374: The pattern <__table@1, __ring_gen@1, 0, __hash@1> can never match the type <reference(),integer(),pos_integer(),non_neg_integer()>
lib/hash_ring/ets.ex:380: The call ets:next(_table@1::reference(),{integer(),non_neg_integer()}) does not have a term of type atom() | ets:tid() (with opaque subterms) as 1st argument
done (warnings were emitted)
```

Dialyzer run after my changes:
```bash
❯ mix dialyzer
Checking PLT...
[:compiler, :elixir, :kernel, :stdlib]
PLT is up to date!
Starting Dialyzer
dialyzer args: [
  check_plt: false,
  init_plt: '/Users/quinn/dev/ex_hash_ring/_build/dev/dialyxir_erlang-21.2.5_elixir-1.8.1_deps-dev.plt',
  files_rec: ['/Users/quinn/dev/ex_hash_ring/_build/dev/lib/ex_hash_ring/ebin'],
  warnings: [:unknown]
]
done in 0m1.27s
done (passed successfully)
```