### PR TITLE
Handle previously invalid replicas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ matrix.otp-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,38 @@ jobs:
             otp-version: 20.3
           - elixir-version: 1.7.4
             otp-version: 21.3
+          - elixir-version: 1.7.4
+            otp-version: 22.3
+          - elixir-version: 1.8.2
+            otp-version: 20.3
+          - elixir-version: 1.8.2
+            otp-version: 21.3
+          - elixir-version: 1.8.2
+            otp-version: 22.3
+          - elixir-version: 1.9.4
+            otp-version: 20.3
+          - elixir-version: 1.9.4
+            otp-version: 21.3
+          - elixir-version: 1.9.4
+            otp-version: 22.3
+          - elixir-version: 1.10.4
+            otp-version: 21.3
+          - elixir-version: 1.10.4
+            otp-version: 22.3
+          - elixir-version: 1.11.4
+            otp-version: 21.3
+          - elixir-version: 1.11.4
+            otp-version: 22.3
+          - elixir-version: 1.11.4
+            otp-version: 23.3
+          - elixir-version: 1.11.4
+            otp-version: 24.0
+          - elixir-version: 1.12.1
+            otp-version: 22.3
+          - elixir-version: 1.12.1
+            otp-version: 23.3
+          - elixir-version: 1.12.1
+            otp-version: 24.0
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/lib/ex_hash_ring/node.ex
+++ b/lib/ex_hash_ring/node.ex
@@ -12,6 +12,8 @@ defmodule ExHashRing.Node do
 
   @typedoc """
   Replicas is a count of how many times a Node should be placed into a Ring.
+
+  Replica counts less than 1 are ignored.
   """
   @type replicas :: pos_integer()
 
@@ -76,10 +78,14 @@ defmodule ExHashRing.Node do
   ## Private
 
   @spec do_expand(node :: t, acc :: [virtual()]) :: [virtual()]
-  defp do_expand({name, replicas}, acc) do
+  defp do_expand({name, replicas}, acc) when replicas > 0 do
     Enum.reduce(0..(replicas - 1), acc, fn replica, acc ->
       [{Hash.of("#{name}#{replica}"), name} | acc]
     end)
+  end
+
+  defp do_expand(_, acc) do
+    acc
   end
 
   @spec do_sort([virtual()]) :: [virtual()]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExHashRing.HashRing.Mixfile do
   def project do
     [
       app: :ex_hash_ring,
-      version: "6.0.0",
+      version: "6.0.1",
       elixir: "~> 1.3",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -30,6 +30,36 @@ defmodule ExHashRing.Node.Test do
       assert Map.get(counts, "test-node-a") == 2
       assert Map.get(counts, "test-node-b") == 3
     end
+
+    test "zero-replicas are dropped" do
+      nodes = [
+        {"test-node-a", 0},
+        {"test-node-b", 3}
+      ]
+
+      counts =
+        nodes
+        |> Node.expand(5)
+        |> counts()
+
+      refute Map.has_key?(counts, "test-node-a")
+      assert Map.get(counts, "test-node-b") == 3
+    end
+
+    test "negative-replicas are dropped" do
+      nodes = [
+        {"test-node-a", -1},
+        {"test-node-b", 3}
+      ]
+
+      counts =
+        nodes
+        |> Node.expand(5)
+        |> counts()
+
+      refute Map.has_key?(counts, "test-node-a")
+      assert Map.get(counts, "test-node-b") == 3
+    end
   end
 
   describe "expand/2" do
@@ -45,6 +75,36 @@ defmodule ExHashRing.Node.Test do
         |> counts()
 
       assert Map.get(counts, "test-node-a") == 2
+      assert Map.get(counts, "test-node-b") == 3
+    end
+
+    test "handles a list of all Node.t() with zero-replica count (ignores the replicas argument)" do
+      nodes = [
+        {"test-node-a", 0},
+        {"test-node-b", 3}
+      ]
+
+      counts =
+        nodes
+        |> Node.expand(5)
+        |> counts()
+
+      refute Map.has_key?(counts, "test-node-a")
+      assert Map.get(counts, "test-node-b") == 3
+    end
+
+    test "handles a list of all Node.t() with negative-replica count (ignores the replicas argument)" do
+      nodes = [
+        {"test-node-a", -1},
+        {"test-node-b", 3}
+      ]
+
+      counts =
+        nodes
+        |> Node.expand(5)
+        |> counts()
+
+      refute Map.has_key?(counts, "test-node-a")
       assert Map.get(counts, "test-node-b") == 3
     end
 
@@ -77,6 +137,29 @@ defmodule ExHashRing.Node.Test do
       assert Map.get(counts, "test-node-b") == 2
       assert Map.get(counts, "test-node-c") == 5
       assert Map.get(counts, "test-node-d") == 3
+    end
+
+    test "handles a list of mixed Node.t() and Node.name() with zero and negative replicas (ignores replicas argument for Node.t(), uses it for Node.name())" do
+      nodes = [
+        "test-node-a",
+        {"test-node-b", 0},
+        "test-node-c",
+        {"test-node-d", -1},
+        "test-node-e",
+        {"test-node-f", 2}
+      ]
+
+      counts =
+        nodes
+        |> Node.expand(5)
+        |> counts()
+
+      assert Map.get(counts, "test-node-a") == 5
+      refute Map.has_key?(counts, "test-node-b")
+      assert Map.get(counts, "test-node-c") == 5
+      refute Map.has_key?(counts, "test-node-d")
+      assert Map.get(counts, "test-node-e") == 5
+      assert Map.get(counts, "test-node-f") == 2
     end
   end
 


### PR DESCRIPTION
t:Node.replicas/0 is defined as pos_integer().

Previously if a value less than 1 was provided the library would use
this in a range and the results would often be wrong an counter
intuitive.  For instance, replicas = 0 would result in two replicas,
[1, 0].  Replicas = -1 would result in three replicas, [1, 0, -1]

Guard has been added so that replicas < 1 expand into the empty set, [].