### PR TITLE
Allow callers to specify timeouts on Ring operations

### DIFF
--- a/lib/ex_hash_ring/configuration.ex
+++ b/lib/ex_hash_ring/configuration.ex
@@ -62,6 +62,16 @@ defmodule ExHashRing.Configuration do
   end
 
   @doc """
+  Get the default operation timeout for ring operations. Unlike other configuration values,
+  this can only be configured at compile time.
+  """
+  defmacro get_default_operation_timeout() do
+    quote do
+      Application.compile_env(:ex_hash_ring, :default_operation_timeout, 5000)
+    end
+  end
+
+  @doc """
   Puts the history depth.
   """
   @spec put_depth(depth :: Ring.depth()) :: :ok

--- a/lib/ex_hash_ring/ring.ex
+++ b/lib/ex_hash_ring/ring.ex
@@ -9,6 +9,10 @@ defmodule ExHashRing.Ring do
 
   alias ExHashRing.{Configuration, Hash, Info, Node, Utils}
 
+  require ExHashRing.Configuration
+
+  @default_operation_timeout Configuration.get_default_operation_timeout()
+
   @compile {:inline,
             do_find_historical_nodes: 5,
             do_find_nodes_in_table: 7,
@@ -157,7 +161,7 @@ defmodule ExHashRing.Ring do
   """
   @spec add_node(ring(), Node.name(), Node.replicas() | nil, timeout :: timeout()) ::
           {:ok, [Node.t()]} | {:error, :node_exists}
-  def add_node(ring, node_name, num_replicas \\ nil, timeout \\ 5000)
+  def add_node(ring, node_name, num_replicas \\ nil, timeout \\ @default_operation_timeout)
 
   def add_node(ring, node_name, nil, timeout) do
     GenServer.call(ring, {:add_nodes, [node_name]}, timeout)
@@ -172,7 +176,7 @@ defmodule ExHashRing.Ring do
   """
   @spec add_nodes(ring(), nodes :: [Node.definition()], timeout :: timeout()) ::
           {:ok, [Node.t()]} | {:error, :node_exists}
-  def add_nodes(ring, nodes, timeout \\ 5000) do
+  def add_nodes(ring, nodes, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, {:add_nodes, nodes}, timeout)
   end
 
@@ -266,7 +270,7 @@ defmodule ExHashRing.Ring do
   """
   @spec force_gc(ring(), generation() | :pending, timeout :: timeout()) ::
           :ok | {:error, :not_pending}
-  def force_gc(ring, generation, timeout \\ 5000) do
+  def force_gc(ring, generation, timeout \\ @default_operation_timeout) do
     case generation do
       :pending ->
         GenServer.call(ring, :force_gc, timeout)
@@ -290,7 +294,7 @@ defmodule ExHashRing.Ring do
   Retrieves the current set of node names from the ring.
   """
   @spec get_nodes(ring(), timeout :: timeout()) :: {:ok, [Node.name()]}
-  def get_nodes(ring, timeout \\ 5000) do
+  def get_nodes(ring, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, :get_nodes, timeout)
   end
 
@@ -298,7 +302,7 @@ defmodule ExHashRing.Ring do
   Retrieves the current set of nodes as tuples of {name, replicas} from the ring.
   """
   @spec get_nodes_with_replicas(ring(), timeout :: timeout()) :: {:ok, [Node.t()]}
-  def get_nodes_with_replicas(ring, timeout \\ 5000) do
+  def get_nodes_with_replicas(ring, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, :get_nodes_with_replicas, timeout)
   end
 
@@ -306,7 +310,7 @@ defmodule ExHashRing.Ring do
   Retrieves the current set of overrides from the ring.
   """
   @spec get_overrides(ring(), timeout :: timeout()) :: {:ok, overrides()}
-  def get_overrides(ring, timeout \\ 5000) do
+  def get_overrides(ring, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, :get_overrides, timeout)
   end
 
@@ -314,7 +318,7 @@ defmodule ExHashRing.Ring do
   Retrieves a list of pending gc generations.
   """
   @spec get_pending_gcs(ring(), timeout :: timeout()) :: {:ok, [generation()]}
-  def get_pending_gcs(ring, timeout \\ 5000) do
+  def get_pending_gcs(ring, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, :get_pending_gcs, timeout)
   end
 
@@ -331,7 +335,7 @@ defmodule ExHashRing.Ring do
   """
   @spec remove_node(ring(), name :: Node.name(), timeout :: timeout()) ::
           {:ok, [Node.t()]} | {:error, :node_not_exists}
-  def remove_node(ring, name, timeout \\ 5000) do
+  def remove_node(ring, name, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, {:remove_nodes, [name]}, timeout)
   end
 
@@ -340,7 +344,7 @@ defmodule ExHashRing.Ring do
   """
   @spec remove_nodes(ring(), names :: [Node.name()]) ::
           {:ok, [Node.t()]} | {:error, :node_not_exists}
-  def remove_nodes(ring, names, timeout \\ 5000) do
+  def remove_nodes(ring, names, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, {:remove_nodes, names}, timeout)
   end
 
@@ -349,7 +353,7 @@ defmodule ExHashRing.Ring do
   """
   @spec set_nodes(ring(), nodes :: [Node.definition()], timeout :: timeout()) ::
           {:ok, [Node.t()]}
-  def set_nodes(ring, nodes, timeout \\ 5000) do
+  def set_nodes(ring, nodes, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, {:set_nodes, nodes}, timeout)
   end
 
@@ -357,7 +361,7 @@ defmodule ExHashRing.Ring do
   Replaces the overrides in the ring with new overrides.
   """
   @spec set_overrides(ring(), overrides(), timeout :: timeout()) :: {:ok, overrides()}
-  def set_overrides(ring, overrides, timeout \\ 5000) do
+  def set_overrides(ring, overrides, timeout \\ @default_operation_timeout) do
     GenServer.call(ring, {:set_overrides, overrides}, timeout)
   end
 

--- a/lib/ex_hash_ring/ring.ex
+++ b/lib/ex_hash_ring/ring.ex
@@ -155,25 +155,25 @@ defmodule ExHashRing.Ring do
   @doc """
   Adds a node to the existing set of nodes in the ring.
   """
-  @spec add_node(ring(), Node.name(), Node.replicas() | nil) ::
+  @spec add_node(ring(), Node.name(), Node.replicas() | nil, timeout :: timeout()) ::
           {:ok, [Node.t()]} | {:error, :node_exists}
-  def add_node(ring, node_name, num_replicas \\ nil)
+  def add_node(ring, node_name, num_replicas \\ nil, timeout \\ 5000)
 
-  def add_node(ring, node_name, nil) do
-    GenServer.call(ring, {:add_nodes, [node_name]})
+  def add_node(ring, node_name, nil, timeout) do
+    GenServer.call(ring, {:add_nodes, [node_name]}, timeout)
   end
 
-  def add_node(ring, node_name, num_replicas) do
-    GenServer.call(ring, {:add_nodes, [{node_name, num_replicas}]})
+  def add_node(ring, node_name, num_replicas, timeout) do
+    GenServer.call(ring, {:add_nodes, [{node_name, num_replicas}]}, timeout)
   end
 
   @doc """
   Adds multiple nodes to the existing set of nodes in the ring.
   """
-  @spec add_nodes(ring(), nodes :: [Node.definition()]) ::
+  @spec add_nodes(ring(), nodes :: [Node.definition()], timeout :: timeout()) ::
           {:ok, [Node.t()]} | {:error, :node_exists}
-  def add_nodes(ring, nodes) do
-    GenServer.call(ring, {:add_nodes, nodes})
+  def add_nodes(ring, nodes, timeout \\ 5000) do
+    GenServer.call(ring, {:add_nodes, nodes}, timeout)
   end
 
   @doc """
@@ -251,19 +251,29 @@ defmodule ExHashRing.Ring do
   @doc """
   Forces a garbage collection of any generations that are pending garbage collection. Returns the
   generations that were collected.
+
+  This is equivalent to `force_gc(ring, :pending)`.
   """
   @spec force_gc(ring()) :: {:ok, [generation()]}
   def force_gc(ring) do
-    GenServer.call(ring, :force_gc)
+    force_gc(ring, :pending)
   end
 
   @doc """
-  Forces a garbage collection of a specific generation, the generation must be pending or else
-  `{:error, :not_pending}` is returned.
+  Forces a garbage collection of a specific generation, all generations pending garbage collection
+  if `:pending` is specified. If a specific generation is specified, the it must be pending or
+  else `{:error, :not_pending}` is returned.
   """
-  @spec force_gc(ring(), generation()) :: :ok | {:error, :not_pending}
-  def force_gc(ring, generation) do
-    GenServer.call(ring, {:force_gc, generation})
+  @spec force_gc(ring(), generation() | :pending, timeout :: timeout()) ::
+          :ok | {:error, :not_pending}
+  def force_gc(ring, generation, timeout \\ 5000) do
+    case generation do
+      :pending ->
+        GenServer.call(ring, :force_gc, timeout)
+
+      generation ->
+        GenServer.call(ring, {:force_gc, generation}, timeout)
+    end
   end
 
   @doc """
@@ -279,33 +289,33 @@ defmodule ExHashRing.Ring do
   @doc """
   Retrieves the current set of node names from the ring.
   """
-  @spec get_nodes(ring()) :: {:ok, [Node.name()]}
-  def get_nodes(ring) do
-    GenServer.call(ring, :get_nodes)
+  @spec get_nodes(ring(), timeout :: timeout()) :: {:ok, [Node.name()]}
+  def get_nodes(ring, timeout \\ 5000) do
+    GenServer.call(ring, :get_nodes, timeout)
   end
 
   @doc """
   Retrieves the current set of nodes as tuples of {name, replicas} from the ring.
   """
-  @spec get_nodes_with_replicas(ring()) :: {:ok, [Node.t()]}
-  def get_nodes_with_replicas(ring) do
-    GenServer.call(ring, :get_nodes_with_replicas)
+  @spec get_nodes_with_replicas(ring(), timeout :: timeout()) :: {:ok, [Node.t()]}
+  def get_nodes_with_replicas(ring, timeout \\ 5000) do
+    GenServer.call(ring, :get_nodes_with_replicas, timeout)
   end
 
   @doc """
   Retrieves the current set of overrides from the ring.
   """
-  @spec get_overrides(ring()) :: {:ok, overrides()}
-  def get_overrides(ring) do
-    GenServer.call(ring, :get_overrides)
+  @spec get_overrides(ring(), timeout :: timeout()) :: {:ok, overrides()}
+  def get_overrides(ring, timeout \\ 5000) do
+    GenServer.call(ring, :get_overrides, timeout)
   end
 
   @doc """
   Retrieves a list of pending gc generations.
   """
-  @spec get_pending_gcs(ring()) :: {:ok, [generation()]}
-  def get_pending_gcs(ring) do
-    GenServer.call(ring, :get_pending_gcs)
+  @spec get_pending_gcs(ring(), timeout :: timeout()) :: {:ok, [generation()]}
+  def get_pending_gcs(ring, timeout \\ 5000) do
+    GenServer.call(ring, :get_pending_gcs, timeout)
   end
 
   @doc """
@@ -319,9 +329,10 @@ defmodule ExHashRing.Ring do
   @doc """
   Removes a node from the ring by its name.
   """
-  @spec remove_node(ring(), name :: Node.name()) :: {:ok, [Node.t()]} | {:error, :node_not_exists}
-  def remove_node(ring, name) do
-    GenServer.call(ring, {:remove_nodes, [name]})
+  @spec remove_node(ring(), name :: Node.name(), timeout :: timeout()) ::
+          {:ok, [Node.t()]} | {:error, :node_not_exists}
+  def remove_node(ring, name, timeout \\ 5000) do
+    GenServer.call(ring, {:remove_nodes, [name]}, timeout)
   end
 
   @doc """
@@ -329,24 +340,25 @@ defmodule ExHashRing.Ring do
   """
   @spec remove_nodes(ring(), names :: [Node.name()]) ::
           {:ok, [Node.t()]} | {:error, :node_not_exists}
-  def remove_nodes(ring, names) do
-    GenServer.call(ring, {:remove_nodes, names})
+  def remove_nodes(ring, names, timeout \\ 5000) do
+    GenServer.call(ring, {:remove_nodes, names}, timeout)
   end
 
   @doc """
   Replaces the nodes in the ring with a new set of nodes.
   """
-  @spec set_nodes(ring(), nodes :: [Node.definition()]) :: {:ok, [Node.t()]}
-  def set_nodes(ring, nodes) do
-    GenServer.call(ring, {:set_nodes, nodes})
+  @spec set_nodes(ring(), nodes :: [Node.definition()], timeout :: timeout()) ::
+          {:ok, [Node.t()]}
+  def set_nodes(ring, nodes, timeout \\ 5000) do
+    GenServer.call(ring, {:set_nodes, nodes}, timeout)
   end
 
   @doc """
   Replaces the overrides in the ring with new overrides.
   """
-  @spec set_overrides(ring(), overrides()) :: {:ok, overrides()}
-  def set_overrides(ring, overrides) do
-    GenServer.call(ring, {:set_overrides, overrides})
+  @spec set_overrides(ring(), overrides(), timeout :: timeout()) :: {:ok, overrides()}
+  def set_overrides(ring, overrides, timeout \\ 5000) do
+    GenServer.call(ring, {:set_overrides, overrides}, timeout)
   end
 
   ## Server

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExHashRing.HashRing.Mixfile do
     [
       app: :ex_hash_ring,
       version: "6.0.4",
-      elixir: "~> 1.3",
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/ring_test.exs
+++ b/test/ring_test.exs
@@ -503,12 +503,12 @@ defmodule ExHashRing.Ring.Operations.Test do
     assert ring_ets_table_size(name) == 1024
   end
 
-  test "ring gen gc all with :pending specifier", %{name: name} do
+  test "ring gen gc all with :all_pending specifier", %{name: name} do
     {:ok, _} = Ring.remove_node(name, "c")
     assert Ring.get_generation(name) == {:ok, 2}
 
-    assert Ring.force_gc(name, :pending) == {:ok, [1]}
-    assert Ring.force_gc(name, :pending) == {:ok, []}
+    assert Ring.force_gc(name, :all_pending) == {:ok, [1]}
+    assert Ring.force_gc(name, :all_pending) == {:ok, []}
 
     # Break the veil and look under the hood and make sure that we don't have any old things in it anymore.
     assert count_generation_entries(name, 1) == 0

--- a/test/ring_test.exs
+++ b/test/ring_test.exs
@@ -503,6 +503,18 @@ defmodule ExHashRing.Ring.Operations.Test do
     assert ring_ets_table_size(name) == 1024
   end
 
+  test "ring gen gc all with :pending specifier", %{name: name} do
+    {:ok, _} = Ring.remove_node(name, "c")
+    assert Ring.get_generation(name) == {:ok, 2}
+
+    assert Ring.force_gc(name, :pending) == {:ok, [1]}
+    assert Ring.force_gc(name, :pending) == {:ok, []}
+
+    # Break the veil and look under the hood and make sure that we don't have any old things in it anymore.
+    assert count_generation_entries(name, 1) == 0
+    assert ring_ets_table_size(name) == 1024
+  end
+
   test "automatic ring gc", %{name: name} do
     Configuration.put_gc_delay(50)
     on_exit(fn -> Configuration.clear_gc_delay() end)


### PR DESCRIPTION
There are several `Ring` operations which require reaching out to the underlying `GenServer`, but depending on the size of your ring, the default timeout may not be a sufficient amount of time to perform `Ring` operations. This adds timeouts to all of the functions in `Ring` which reach out to this `GenServer`.

One note, `force_gc` could not have a simple timeout attached to it, because there would be an arity conflict between these two function heads

```
def force_gc(ring, timeout \\ 5000)
def force_gc(ring, generation, timeout \\ 5000)
```

I've opted to leave `force_gc/1` as-is, and add the ability to replicate its functionality from `force_gc/2`, so a timeout can still be specified