### PR TITLE
Fix CI by reducing test matrix, upgrade cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,24 @@ jobs:
             otp-version: 24.3
           - elixir-version: 1.15.5
             otp-version: 25.3
+          - elixir-version: 1.15.5
+            otp-version: 26.2
+          - elixir-version: 1.16.2
+            otp-version: 25.3
+          - elixir-version: 1.16.2
+            otp-version: 26.2
+          - elixir-version: 1.17.3
+            otp-version: 25.3
+          - elixir-version: 1.17.3
+            otp-version: 26.2
+          - elixir-version: 1.17.3
+            otp-version: 27.0
+          - elixir-version: 1.18.3
+            otp-version: 25.3
+          - elixir-version: 1.18.3
+            otp-version: 26.2
+          - elixir-version: 1.18.3
+            otp-version: 27.2
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,46 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir-version: 1.6.6
-            otp-version: 20.3
-          - elixir-version: 1.6.6
-            otp-version: 21.3
-          - elixir-version: 1.7.4
-            otp-version: 20.3
-          - elixir-version: 1.7.4
-            otp-version: 21.3
-          - elixir-version: 1.7.4
-            otp-version: 22.3
-          - elixir-version: 1.8.2
-            otp-version: 20.3
-          - elixir-version: 1.8.2
-            otp-version: 21.3
-          - elixir-version: 1.8.2
-            otp-version: 22.3
-          - elixir-version: 1.9.4
-            otp-version: 20.3
-          - elixir-version: 1.9.4
-            otp-version: 21.3
-          - elixir-version: 1.9.4
-            otp-version: 22.3
-          - elixir-version: 1.10.4
-            otp-version: 21.3
-          - elixir-version: 1.10.4
-            otp-version: 22.3
-          - elixir-version: 1.11.4
-            otp-version: 21.3
-          - elixir-version: 1.11.4
-            otp-version: 22.3
-          - elixir-version: 1.11.4
-            otp-version: 23.3
-          - elixir-version: 1.11.4
-            otp-version: 24.0
-          - elixir-version: 1.12.1
-            otp-version: 22.3
-          - elixir-version: 1.12.1
-            otp-version: 23.3
-          - elixir-version: 1.12.1
-            otp-version: 24.0
+          - elixir-version: 1.12.3
+            otp-version: 24.3
+          - elixir-version: 1.15.5
+            otp-version: 25.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
@@ -62,7 +26,7 @@ jobs:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ matrix.otp-version }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-${{ matrix.elixir-version }}-${{ matrix.otp-version}}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
It seems that `hex.pm` has removed a lot of the OTP versions in this test matrix ([list here](https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt)), causing our builds to fail.

Additionally, `actions/cache@v2` has been hard-deprecated, so we must upgrade to something more recent in order for these builds to pass.